### PR TITLE
FAT-25452: Add dependency on app-platform-complete

### DIFF
--- a/app-reading-room.template.json
+++ b/app-reading-room.template.json
@@ -5,8 +5,8 @@
   "platform": "complete",
   "dependencies": [
     {
-      "name": "app-platform-minimal",
-      "version": "^2.1.0-SNAPSHOT"
+      "name": "app-platform-complete",
+      "version": "^3.0.0-SNAPSHOT"
     },
     {
       "name": "app-inventory",

--- a/application.template.json
+++ b/application.template.json
@@ -5,8 +5,8 @@
   "platform": "complete",
   "dependencies": [
     {
-      "name": "app-platform-minimal",
-      "version": "^2.1.0-SNAPSHOT",
+      "name": "app-platform-complete",
+      "version": "^3.0.0-SNAPSHOT",
       "preRelease": "only"
     },
     {


### PR DESCRIPTION
## Purpose
Jira: https://folio-org.atlassian.net/browse/FAT-25452
Add dependency on `app-platform-complete`, because it provides the following interfaces (required for ui-reading-room): 
- feesfines 19.1
- automated-patron-blocks 0.1